### PR TITLE
feat: add similarity slider to filter and highlight sentences

### DIFF
--- a/sentence_plagiarism/visualization/templates/plagiarism_report.css
+++ b/sentence_plagiarism/visualization/templates/plagiarism_report.css
@@ -88,3 +88,22 @@ pre, code {
     padding: 10px;
     overflow-x: auto;
 }
+
+.slider-container {
+    margin-bottom: 20px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.slider-container label {
+    font-weight: bold;
+}
+
+.slider-container input[type="range"] {
+    width: 200px;
+}
+
+.slider-value {
+    font-weight: bold;
+}

--- a/sentence_plagiarism/visualization/templates/plagiarism_report.js
+++ b/sentence_plagiarism/visualization/templates/plagiarism_report.js
@@ -33,6 +33,41 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     });
 
+    // Similarity slider functionality
+    const slider = document.getElementById('similarity-slider');
+    const sliderValueDisplay = document.getElementById('slider-value');
+
+    slider.addEventListener('input', function() {
+        const similarityThreshold = parseFloat(slider.value) / 100; // Convert percentage to 0-1 range
+        sliderValueDisplay.textContent = slider.value + '%';
+
+        document.querySelectorAll('.plagiarized').forEach(el => {
+            const similarity = parseFloat(el.getAttribute('data-similarity'));
+            if (similarity >= similarityThreshold) {
+                el.classList.remove('hidden');
+            } else {
+                el.classList.add('hidden');
+            }
+        });
+
+        updateHighlightedCount();
+    });
+
+    const highlightedCountDisplay = document.getElementById('highlighted-count');
+
+    function updateHighlightedCount() {
+        const highlightedCount = document.querySelectorAll('.plagiarized:not(.hidden)').length;
+        highlightedCountDisplay.textContent = `Highlighted Sentences: ${highlightedCount}`;
+    }
+
+    // Update count on filter button clicks
+    document.querySelectorAll('.filter-btn, #show-all-btn, #hide-all-btn').forEach(btn => {
+        btn.addEventListener('click', updateHighlightedCount);
+    });
+
+    // Initial count update
+    updateHighlightedCount();
+
     function setActiveButton(activeBtn) {
         document.querySelectorAll('.control-btn').forEach(btn => {
             btn.classList.remove('active');

--- a/sentence_plagiarism/visualization/templates/plagiarism_report_template.html
+++ b/sentence_plagiarism/visualization/templates/plagiarism_report_template.html
@@ -16,6 +16,14 @@
     <div class="controls">
         <h2>{subtitle}</h2>
         <p>{subsubtitle}</p>
+        <div class="slider-container">
+            <label for="similarity-slider">Similarity Threshold:</label>
+            <input type="range" id="similarity-slider" min="0" max="100" value="50" step="1">
+            <span id="slider-value">50%</span>
+        </div>
+        <div id="highlighted-count" style="font-weight: bold; margin-bottom: 10px;">
+            Highlighted Sentences: 0
+        </div>
         <div class="buttons">
             {filter_buttons}
         </div>


### PR DESCRIPTION
This PR introduces a similarity slider to dynamically filter plagiarized sentences based on a chosen threshold. It updates the displayed count of highlighted sentences and ensures proper styling and functionality for the slider across the interface. Also, the initial count is set and updated with interactions.